### PR TITLE
Add `!findquote` alias for `!quote`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "eris"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64-stream 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eris"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Andreas Ots <qrpth@qrpth.eu>"]
 license = "Apache-2.0"
 readme = "README.md"

--- a/src/commands/static_response.rs
+++ b/src/commands/static_response.rs
@@ -121,6 +121,15 @@ fn replace_emojis<'a, S: Into<String>, I: Iterator<Item = &'a Emoji>>(
 }
 
 fn static_response_impl(ctx: &mut Context, msg: &Message, command: &str) -> Result<(), Error> {
+    info!("Static command received";
+        "command_name" => ?command,
+        "message" => ?&msg.content,
+        "message.id" => ?msg.id.0,
+        "from.id" => ?msg.author.id.0,
+        "from.name" => ?&msg.author.name,
+        "from.discriminator" => ?msg.author.discriminator,
+    );
+
     let response = {
         let data = ctx.data.read();
         let lrrbot = data.extract::<LRRbot>()?.clone();
@@ -136,15 +145,6 @@ fn static_response_impl(ctx: &mut Context, msg: &Message, command: &str) -> Resu
     };
 
     if let Response::Some { access, response } = response {
-        info!("Static command received";
-            "command_name" => ?command,
-            "message" => ?&msg.content,
-            "message.id" => ?msg.id.0,
-            "from.id" => ?msg.author.id.0,
-            "from.name" => ?&msg.author.name,
-            "from.discriminator" => ?msg.author.discriminator,
-        );
-
         if access.user_has_access(ctx, msg) {
             let response = response.choose(&mut rand::thread_rng());
             if let Some(response) = response {


### PR DESCRIPTION
This also removes the `!quote find` alias. Fortunately it seems like nobody has managed to use yet.