### PR TITLE
systemd: implement sd_notify(3) ourselves

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,7 +662,6 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "levenshtein",
- "libloading",
  "rand",
  "regex",
  "reqwest",
@@ -1492,16 +1491,6 @@ name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
-
-[[package]]
-name = "libloading"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
-dependencies = [
- "cfg-if",
- "windows-targets 0.52.4",
-]
 
 [[package]]
 name = "libm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ influxdb = { version = "0.7.2", default-features = false, features = ["derive", 
 iso8601 = "0.6.1"
 lalrpop-util = { version = "0.20.2", features = ["std", "lexer", "unicode"], default-features = false }
 levenshtein = "1.0.5"
-libloading = "0.8.3"
 rand = { version = "0.8.5", default-features = false, features = ["std", "std_rng"] }
 regex = { version = "1.10.4", default-features = false, features = ["perf", "std", "unicode"] }
 reqwest = { version = "0.11.27", default-features = false, features = ["rustls-tls", "json"] }

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -1,45 +1,50 @@
-use std::ffi::{c_char, c_int, CString};
+use std::os::linux::net::SocketAddrExt;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::net::SocketAddr;
 
 use anyhow::{Context, Error};
-use libloading::Library;
+use tokio::net::UnixDatagram;
 
 pub struct Notify {
-    libsystemd: Library,
+    socket: UnixDatagram,
 }
 
 impl Notify {
     pub fn new() -> Result<Self, Error> {
-        let libsystemd = unsafe {
-            Library::new(libloading::library_filename("systemd"))
-                .context("failed to load libsystemd")?
+        let socket_name = std::env::var_os("NOTIFY_SOCKET").context("$NOTIFY_SOCKET is not set")?;
+
+        let addr = if socket_name.as_bytes().starts_with(b"/") {
+            SocketAddr::from_pathname(&socket_name)
+                .context("failed to construct the socket address from path")?
+        } else if socket_name.as_bytes().starts_with(b"@") {
+            SocketAddr::from_abstract_name(&socket_name.as_bytes()[1..])
+                .context("failed to construct the socket address from abstract name")?
+        } else {
+            anyhow::bail!("unsupported socket {socket_name:?}")
         };
 
-        Ok(Self { libsystemd })
+        let std_socket = std::os::unix::net::UnixDatagram::unbound()
+            .context("failed to create a Unix datagram socket")?;
+        std_socket.connect_addr(&addr).with_context(|| format!("failed to connect to {addr:?}"))?;
+        std_socket.set_nonblocking(true).context("failed to set the socket to non-blocking")?;
+
+        let socket = UnixDatagram::from_std(std_socket)
+            .context("failed to convert the socket to a Tokio socket")?;
+
+        Ok(Self { socket })
     }
 
-    fn notify(&self, state: &str) -> Result<bool, Error> {
-        let state = CString::new(state).context("failed to convert the state")?;
-        unsafe {
-            let sd_notify = self
-                .libsystemd
-                .get::<unsafe extern "C" fn(c_int, *const c_char) -> c_int>(b"sd_notify")
-                .context("failed to find `sd_notify` in libsystemd")?;
-            match sd_notify(0, state.as_ptr()) {
-                error if error < 0 => Err(Error::from(std::io::Error::from_raw_os_error(-error))
-                    .context("`sd_notify(3)` failed")),
-                0 => Ok(false),
-                _ => Ok(true),
-            }
-        }
-    }
+    async fn notify(&self, state: &str) -> Result<(), Error> {
+        self.socket.send(state.as_bytes()).await.context("failed to send notification")?;
 
-    pub fn ready(&self) -> Result<(), Error> {
-        self.notify("READY=1")?;
         Ok(())
     }
 
-    pub fn feed_watchdog(&self) -> Result<(), Error> {
-        self.notify("WATCHDOG=1")?;
-        Ok(())
+    pub async fn ready(&self) -> Result<(), Error> {
+        self.notify("READY=1").await
+    }
+
+    pub async fn feed_watchdog(&self) -> Result<(), Error> {
+        self.notify("WATCHDOG=1").await
     }
 }


### PR DESCRIPTION
During the xz-utils kerfuffle I learned that `sd_notify(3)` is actually pretty simple to implement ourselves.